### PR TITLE
simplify reactsTo function by using isActionOf instead of switch

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ export * from "./types"
 
 import List from "./list"
 import moize from "moize"
+import {F1} from "./types"
 
 export type JSXElement = React.ReactElement<any>
 
@@ -251,3 +252,15 @@ export function log<T>(value: T, ...others: any[]) {
 export type Mutable<T extends { [x: string]: any }, K extends string> = {
   [P in K]: T[P];
 }
+
+export type ActionOf = string | F1<AnyAction, boolean>
+
+export const isActionOf = <A extends AnyAction>(actionsOf: List<ActionOf>) =>
+  (action: AnyAction): action is A => {
+    return actionsOf.some(actionOf => {
+      if (typeof actionOf === "string")
+        return action.type === actionOf
+      else
+        return actionOf(action)
+    })
+  }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import List from "./list"
 export type Nothing = null | undefined | void
 export type Maybe<T> = T | Nothing
 export type Type<T> = (x: T) => T
+export type F1<A, B> = (x: A) => B
 
 export interface DeepList<T> extends List<T | DeepList<T>> {}
 export type Deep<T> = T | DeepList<T>


### PR DESCRIPTION
```typescript
export const reactsTo = (action: AnyAction): action is Action => {
  switch (action.type) {
    case InitType:
    case GotoType:
    case ActionType.Loaded:
      return true
    default:
      return Dashboard.reactsTo(action) ||
        Network.reactsTo(action)
  }
}
```

becomes
```typescript
export const reactsTo = isActionOf<Action>(
  [InitType, GotoType, ActionType.Loaded, Dashboard.reactsTo, Network.reactsTo]
)
```
:smile: 