### PR TITLE
Re enable hmr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,16 @@
       "integrity": "sha512-eVAb52MJ4lfPLiO9VvTgv8KaZDEIqCwhv+lXOMLlt4C1YHTShgmMULEg0RrCbnqfYd6QKfHsMp0MiX0vWISpSw==",
       "dev": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/node": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
@@ -41,49 +51,24 @@
       }
     },
     "@types/react-dom": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.0.tgz",
-      "integrity": "sha512-Jp4ufcEEjVJEB0OHq2MCZcE1u3KYUKO6WnSuiU/tZeYeiZxUoQavfa/TZeiIT+1XoN6l0lQVNM30VINZFDeolQ==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-hot-loader": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react-hot-loader/-/react-hot-loader-3.0.5.tgz",
-      "integrity": "sha512-KL0OLo1158WBWv+QoP9Z9f+MupiM9DpwJST52D0AyxUpXFmyzV1VskwRp+RZsnZemMcAPoyBy8od44HuJtuVwQ==",
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.4.tgz",
+      "integrity": "sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==",
       "dev": true,
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/react-redux": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.7.tgz",
-      "integrity": "sha512-q/RakB1m0VLaVNYE9V+oKadXrKs5J7zfMJrsaB90/ubyQUzA45wag3HarJkKJuVNyTVp5N+buMfiwGE0XY6YVg==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.0.9.tgz",
+      "integrity": "sha512-fMVX9SneWWw68d/JoeNUh6hj42kx2G30YhPdCYJTOv3xqbJ1xzIz6tEM/xzi7nBvpNbwZkSa9TMsV06kWOFIIg==",
       "dev": true,
       "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      },
-      "dependencies": {
-        "redux": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
-          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "symbol-observable": "^1.2.0"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "dev": true
-        }
       }
     },
     "@types/redux": {
@@ -180,11 +165,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
-    },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -309,16 +289,6 @@
         }
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -331,11 +301,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -343,9 +308,9 @@
       "dev": true
     },
     "functools-ts": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/functools-ts/-/functools-ts-0.1.0.tgz",
-      "integrity": "sha512-ONPBcbEtZ7sqT8fTobRENA+RNzP/w2pX7B2fLuGDrx58NQJLrb4KZx7rKYApsZOdNOQ2gR/kX99KT5K88QCELw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/functools-ts/-/functools-ts-0.2.0.tgz",
+      "integrity": "sha512-YlMV1kTKnBuMXC2EA9lBxyPD7I4GSz3o8qJe9DdZlaHwZXG8vGW7yoZOoouPv7s7cUTX0kYa39awsiAK3knAqg=="
     },
     "get-params": {
       "version": "0.1.2",
@@ -364,15 +329,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
       }
     },
     "has-ansi": {
@@ -418,6 +374,13 @@
       "requires": {
         "functools-ts": "^0.1.0",
         "rxjs": "^6.4.0"
+      },
+      "dependencies": {
+        "functools-ts": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/functools-ts/-/functools-ts-0.1.1.tgz",
+          "integrity": "sha512-I52p91WZXkf+A/ruVMBLCfqVCzJKGOfRODvXDcyLHWI6XTc0dIel5w+1tJv4on0dhpiOt0xqhZzs6b4AVg+Upg=="
+        }
       }
     },
     "hydra-dispatch-redux": {
@@ -475,28 +438,10 @@
       "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.13.tgz",
       "integrity": "sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g=="
     },
-    "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
     "linked-list": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
       "integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78="
-    },
-    "loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      }
     },
     "lodash": {
       "version": "4.17.11",
@@ -517,14 +462,6 @@
         "js-tokens": "^3.0.0"
       }
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -533,11 +470,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "nanoid": {
       "version": "2.0.1",
@@ -576,11 +508,6 @@
       "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
       "dev": true
     },
-    "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-    },
     "prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.1.tgz",
@@ -606,51 +533,30 @@
         "scheduler": "^0.13.6"
       }
     },
-    "react-hot-loader": {
-      "version": "4.8.7",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.8.7.tgz",
-      "integrity": "sha512-ctWAu8iwp37qd4w1qhjN6neDA1e5bSmAUY46L2l5SeK+i8AfzX+7lrpaLW4TJVaiBv5MlqIzA1ClNnvlvsy5Lg==",
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "lodash": "^4.17.11",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.0.2",
-        "source-map": "^0.7.3"
-      }
-    },
     "react-is": {
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
       "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-redux": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.0.tgz",
-      "integrity": "sha512-EmbC3uLl60pw2VqSSkj6HpZ6jTk12RMrwXMBdYtM6niq0MdEaRq9KYCwpJflkOZj349BLGQm1MI/JO1W96kLWQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.0.3.tgz",
+      "integrity": "sha512-vYZA7ftOYlDk3NetitsI7fLjryt/widNl1SLXYvFenIpm7vjb4ryK0EeFrgn62usg5fYkyIAWNUPKnwWPevKLg==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "hoist-non-react-statics": "^3.2.1",
+        "@babel/runtime": "^7.4.3",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.3"
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
       },
       "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
           "requires": {
-            "react-is": "^16.7.0"
+            "regenerator-runtime": "^0.13.2"
           }
         },
         "loose-envify": {
@@ -660,6 +566,26 @@
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
@@ -812,11 +738,6 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "socketcluster-client": {
       "version": "14.2.2",
       "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.2.2.tgz",
@@ -833,11 +754,6 @@
         "uuid": "3.2.1",
         "ws": "5.1.1"
       }
-    },
-    "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tooling",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Tooling for React",

--- a/package.json
+++ b/package.json
@@ -24,25 +24,22 @@
     "check": "npm run compile && npm run check:format"
   },
   "dependencies": {
-    "functools-ts": "^0.1.0",
+    "functools-ts": "^0.2.0",
     "history": "^4.9.0",
     "react": "^16.8.6",
-    "react-hot-loader": "^4.8.7",
-    "react-redux": "^6.0.0",
+    "react-redux": "^7.0.3",
     "redux-thunk": "^2.3.0",
     "hydra-dispatch": "^0.1.0",
     "hydra-dispatch-redux": "^0.1.0",
     "redux": "^4.0.1",
-    "remote-redux-devtools": "^0.5.16",
-    "rxjs": "^6.4.0"
+    "remote-redux-devtools": "^0.5.16"
   },
   "devDependencies": {
     "@types/history": "^4.6.2",
     "@types/node": "^8.0.54",
     "@types/react": "^16.8.6",
-    "@types/react-dom": "^16.8.0",
-    "@types/react-hot-loader": "^3.0.5",
-    "@types/react-redux": "^6.0.7",
+    "@types/react-dom": "^16.8.4",
+    "@types/react-redux": "^7.0.9",
     "@types/redux": "^3.6.0",
     "@types/redux-devtools-extension": "^2.13.2",
     "@types/remote-redux-devtools": "^0.5.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,6 @@ export interface Opts {
     port: number
   }
   onLoad?: () => any
-//  onHMR?: () => any
 }
 
 const defaultOpts: Opts = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -188,7 +188,6 @@ export const load = function<State extends Router.State<Route>, Route>(
     })
   )(Index)
 
-
   render(
     <Provider store={store!}>
       <View />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,7 @@ export interface Opts {
     port: number
   }
   onLoad?: () => any
-  onHMR?: () => any
+//  onHMR?: () => any
 }
 
 const defaultOpts: Opts = {
@@ -188,6 +188,7 @@ export const load = function<State extends Router.State<Route>, Route>(
       dispatch: dispatcherFromRedux(dispatch)
     })
   )(Index)
+
 
   render(
     <Provider store={store!}>


### PR DESCRIPTION
The name of the branch is quite misleading, i've started going into this direction
and integrate hot module reloading inside of react-tooling
But there is some issue with new version of react-hot-loader
It would not allow to create a hot module inside of a library
I've tried several times to make it work but i got the same error.
The module is unaccepted everytime i do a change in the application
I've debugged inside of the code that does HMR to try to understand why it keep happening
What i have found is that HMR try to solve the module to update going from the bottom module to top module
The top module happened to be the main module (or the module 0 in HMR code term) which HMR doesn't accept that
So after i've moved from the library to application the hot module it worked flawlessly
The new react-hot-loader is much easier to use in the code than the previous one, just call hot(view) and that's finished
The only drawback it is for TypeScript who are forced to use babel now to transpile TypeScript