### PR TITLE
remove export react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tooling",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Tooling for React",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,8 +21,6 @@ export * from "./view"
 
 export type JSXElement = React.ReactElement<any>
 
-export {React, JSX}
-
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 let store: Redux.Store<any>


### PR DESCRIPTION
Remove export React, it can cause some issue with react hooks if the application use a different version from react-tooling.
It's better for the developer to import react themselves