### PR TITLE
allow comparator to be passed to memoized component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,10 @@
 {
   "name": "react-tooling",
+<<<<<<< Updated upstream
   "version": "0.29.0",
+=======
+  "version": "0.30.1",
+>>>>>>> Stashed changes
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "react-tooling",
-<<<<<<< Updated upstream
-  "version": "0.29.0",
-=======
   "version": "0.30.1",
->>>>>>> Stashed changes
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tooling",
-  "version": "0.29.1",
+  "version": "0.30.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Tooling for React",

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,5 +1,7 @@
 import {isDispatch} from "hydra-dispatch"
 import React from "react"
+import { F2 } from "functools-ts"
+// import {F2} from "functools-ts"
 
 export type JSXElement = React.ReactElement<any>
 
@@ -7,7 +9,7 @@ export type View<State> =
   | ((state: State) => JSXElement)
   | {new (state: State): React.Component<State>}
 
-const shallowEqual = (first: any, second: any, logDiff?: boolean): boolean =>
+export const shallowEqual = (first: any, second: any, logDiff?: boolean): boolean =>
   Object.keys(first).every(key => {
     if (
       (first[key] && isDispatch(first[key])) ||
@@ -15,17 +17,20 @@ const shallowEqual = (first: any, second: any, logDiff?: boolean): boolean =>
     )
       return true
     if (logDiff && first[key] !== second[key])
-      console.log("diff: ", first[key], second[key])
+      console.log(`diff: ${key}`, first[key], second[key])
     return first[key] === second[key]
   })
 
 export const memoizeComponent = <S>(
   view: View<S>,
-  logDiff?: boolean
+  logDiff?: boolean,
+  compare?: F2<S, S, boolean>
 ): View<S> => {
   const factory = React.createFactory(view as any)
   return class MemoizedComponent extends React.Component<S> {
     shouldComponentUpdate(nextProps: S) {
+      if (compare)
+        return !compare(this.props, nextProps)
       return !shallowEqual(this.props, nextProps, logDiff)
     }
 


### PR DESCRIPTION
Allow to pass a custom comparator to memoizedComponent function
to have a better control  of how props are compared.